### PR TITLE
[ その他 ] readme.txt に Stable tag を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: post,author
 Requires at least: 5.3
 Tested up to: 6.9
 Requires PHP: 7.4
+Stable tag: 1.27.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- readme.txt に `Stable tag: 1.27.1` を追加
- `Stable tag` が欠落していると WordPress.org のビルドシステムが zip を正しく再生成せず、古いバージョンが配信され続ける問題への対応

Related: vektor-inc/multi-repo-tasks#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プラグインのメタデータを更新し、現在の安定版バージョン情報を明示しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->