### PR TITLE
[ 仕様変更 ][ 7.0 対応 ] メタボックスをブロックエディタネイティブUIに移行してRTC（リアルタイム共同編集）に対応

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -5,6 +5,7 @@ _scss/
 dist/
 tests/
 node_modules/
+src/
 .distignore
 .gitattributes
 .gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 vendor/
+build/
 temp/
 .wp-env.override.json
 .phpunit.result.cache

--- a/hide_controller.php
+++ b/hide_controller.php
@@ -24,7 +24,8 @@ function pad_add_custom_field_user_view_group() {
 	// ビルドファイルが存在する場合はネイティブサイドバーパネルで代替するため、
 	// レガシーメタボックスを非表示にする（__back_compat_meta_box => true）。
 	// ビルドファイルがない場合は従来通りメタボックスを表示する（フォールバック）。
-	$asset_path  = VK_PAD_DIR . 'build/index.asset.php';
+	$base_dir    = defined( 'VK_PAD_DIR' ) ? VK_PAD_DIR : plugin_dir_path( __FILE__ );
+	$asset_path  = $base_dir . 'build/index.asset.php';
 	$has_build   = file_exists( $asset_path );
 	$callback_args = $has_build
 		? array( '__back_compat_meta_box' => true )

--- a/hide_controller.php
+++ b/hide_controller.php
@@ -22,7 +22,12 @@ function pad_add_custom_field_user_view_group() {
 			__( 'Post Author Display', 'vk-post-author-display' ),
 			'pad_content_meta_fields',
 			$post_type,
-			'side'
+			'side',
+			'default',
+			array(
+				// WordPress 7.0 RTC compatibility flag / WordPress 7.0 RTC互換フラグ
+				'__back_compat_meta_box' => true,
+			)
 		);
 	}
 }

--- a/hide_controller.php
+++ b/hide_controller.php
@@ -16,6 +16,10 @@ function pad_add_custom_field_user_view_group() {
 
 	$post_types = pad_display_post_types();
 
+	if ( empty( $post_types ) || ! is_array( $post_types ) ) {
+		return;
+	}
+
 	// WordPress 7.0 RTC compatibility:
 	// ビルドファイルが存在する場合はネイティブサイドバーパネルで代替するため、
 	// レガシーメタボックスを非表示にする（__back_compat_meta_box => true）。

--- a/hide_controller.php
+++ b/hide_controller.php
@@ -26,7 +26,7 @@ function pad_add_custom_field_user_view_group() {
 			'default',
 			array(
 				// WordPress 7.0 RTC compatibility flag / WordPress 7.0 RTC互換フラグ
-				'__back_compat_meta_box' => true,
+				'__back_compat_meta_box' => false,
 			)
 		);
 	}

--- a/hide_controller.php
+++ b/hide_controller.php
@@ -16,6 +16,16 @@ function pad_add_custom_field_user_view_group() {
 
 	$post_types = pad_display_post_types();
 
+	// WordPress 7.0 RTC compatibility:
+	// ビルドファイルが存在する場合はネイティブサイドバーパネルで代替するため、
+	// レガシーメタボックスを非表示にする（__back_compat_meta_box => true）。
+	// ビルドファイルがない場合は従来通りメタボックスを表示する（フォールバック）。
+	$asset_path  = VK_PAD_DIR . 'build/index.asset.php';
+	$has_build   = file_exists( $asset_path );
+	$callback_args = $has_build
+		? array( '__back_compat_meta_box' => true )
+		: array();
+
 	foreach ( $post_types  as $post_type ) {
 		add_meta_box(
 			'post_author_display',
@@ -24,10 +34,7 @@ function pad_add_custom_field_user_view_group() {
 			$post_type,
 			'side',
 			'default',
-			array(
-				// WordPress 7.0 RTC compatibility flag / WordPress 7.0 RTC互換フラグ
-				'__back_compat_meta_box' => false,
-			)
+			$callback_args
 		);
 	}
 }

--- a/inc/register-meta.php
+++ b/inc/register-meta.php
@@ -29,8 +29,8 @@ function pad_register_post_meta() {
 				'single'            => true,
 				'sanitize_callback' => 'sanitize_text_field',
 				'show_in_rest'      => true,
-				'auth_callback'     => function () {
-					return current_user_can( 'edit_posts' );
+				'auth_callback'     => function ( $allowed, $meta_key, $post_id ) {
+					return current_user_can( 'edit_post', $post_id );
 				},
 			)
 		);

--- a/inc/register-meta.php
+++ b/inc/register-meta.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Register post meta for REST API access.
+ * ブロックエディタからREST API経由でメタデータを読み書きするために登録する。
+ *
+ * @package vk-post-author-display
+ */
+
+/**
+ * Register pad_hide_post_author meta key for the REST API.
+ * pad_hide_post_author メタキーをREST APIに登録する。
+ *
+ * @return void
+ */
+function pad_register_post_meta() {
+	$post_types = pad_display_post_types();
+
+	if ( empty( $post_types ) || ! is_array( $post_types ) ) {
+		return;
+	}
+
+	foreach ( $post_types as $post_type ) {
+		register_post_meta(
+			$post_type,
+			'pad_hide_post_author',
+			array(
+				'type'              => 'string',
+				'description'       => 'Hide post author display flag / 著者表示非表示フラグ',
+				'single'            => true,
+				'sanitize_callback' => 'sanitize_text_field',
+				'show_in_rest'      => true,
+				'auth_callback'     => function () {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
+	}
+}
+add_action( 'init', 'pad_register_post_meta' );

--- a/inc/register-meta.php
+++ b/inc/register-meta.php
@@ -27,7 +27,12 @@ function pad_register_post_meta() {
 				'type'              => 'string',
 				'description'       => 'Hide post author display flag / 著者表示非表示フラグ',
 				'single'            => true,
-				'sanitize_callback' => 'sanitize_text_field',
+				'sanitize_callback' => function ( $value ) {
+					// フラグ用途のため 'true' / '' のみ許可する。
+					// sanitize_text_field だと任意文字列が残り、
+					// truthiness 判定で意図しない非表示が起きうる。
+					return ( 'true' === (string) $value ) ? 'true' : '';
+				},
 				'show_in_rest'      => true,
 				'auth_callback'     => function ( $allowed, $meta_key, $post_id ) {
 					return current_user_can( 'edit_post', $post_id );

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "wp-env": "wp-env",
     "sass": "sass --watch assets/_scss:assets/css",
     "sass:build": "sass --style=compressed --no-source-map assets/_scss:assets/css",
-    "build": "gulp replace_text_domain && npm run sass:build",
+    "build": "wp-scripts build --webpack-src-dir=src --output-path=build && gulp replace_text_domain && npm run sass:build",
+    "build:block": "wp-scripts build --webpack-src-dir=src --output-path=build",
+    "start": "wp-scripts start --webpack-src-dir=src --output-path=build",
     "phpunit": "wp-env run tests-cli --env-cwd='wp-content/plugins/vk-post-author-display' vendor/bin/phpunit -c .phpunit.xml --verbose",
     "dist": "composer install --optimize-autoloader --prefer-dist --no-dev && npm run build && bash bin/dist.sh"
   },
@@ -25,8 +27,12 @@
     "url": "https://github.com/vektor-inc/vk-post-author-display/issues"
   },
   "homepage": "https://github.com/vektor-inc/vk-post-author-display#readme",
+  "dependencies": {
+    "@babel/runtime": "^7.29.2"
+  },
   "devDependencies": {
     "@wordpress/env": "10.39.0",
+    "@wordpress/scripts": "^28.4.0",
     "gulp": "^5.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-merge-media-queries": "^0.2.1",

--- a/post-author-display.php
+++ b/post-author-display.php
@@ -83,7 +83,42 @@ require_once VK_PAD_DIR . 'admin/admin.php';
 require_once VK_PAD_DIR . 'admin/admin-profile.php';
 require_once VK_PAD_DIR . 'view.post-author.php';
 new Vk_Post_Author_Box();
+require_once VK_PAD_DIR . 'inc/register-meta.php';
 require_once VK_PAD_DIR . 'hide_controller.php';
+
+/**
+ * Enqueue block editor assets for the native sidebar panel.
+ * ブロックエディタ用ネイティブサイドバーパネルのアセットを読み込む。
+ *
+ * @return void
+ */
+function pad_enqueue_block_editor_assets() {
+	$asset_path = VK_PAD_DIR . 'build/index.asset.php';
+	if ( ! file_exists( $asset_path ) ) {
+		return;
+	}
+
+	$asset_file = include $asset_path;
+
+	wp_enqueue_script(
+		'pad-editor-panel',
+		VK_PAD_URL . 'build/index.js',
+		$asset_file['dependencies'],
+		$asset_file['version'],
+		true
+	);
+
+	wp_localize_script(
+		'pad-editor-panel',
+		'padEditor',
+		array(
+			'postTypes' => array_values( pad_display_post_types() ),
+		)
+	);
+
+	wp_set_script_translations( 'pad-editor-panel', 'vk-post-author-display' );
+}
+add_action( 'enqueue_block_editor_assets', 'pad_enqueue_block_editor_assets' );
 
 // Add a link to this plugin's settings page
 function pad_set_plugin_meta( $links ) {

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
-[ Specification Change ] Add back compat meta box flag for WordPress 7.0 RTC compatibility.
+[ Other ] Add back compat meta box flag for WordPress 7.0 RTC compatibility.
 
 = 1.27.1 =
 [ Specification Change ] Add Requires PHP: 7.4

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,7 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
-[ Other ] Add back compat meta box flag for WordPress 7.0 RTC compatibility.
+[ Specification change ] Migrate meta box to block editor native sidebar panel for WordPress 7.0 RTC (Real-Time Collaboration) compatibility.
 
 = 1.27.1 =
 [ Specification Change ] Add Requires PHP: 7.4

--- a/readme.txt
+++ b/readme.txt
@@ -31,7 +31,6 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
-= 1.27.2 =
 [ Specification Change ] Add back compat meta box flag for WordPress 7.0 RTC compatibility.
 
 = 1.27.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,9 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
+= 1.27.2 =
+[ Specification Change ] Add back compat meta box flag for WordPress 7.0 RTC compatibility.
+
 = 1.27.1 =
 [ Specification Change ] Add Requires PHP: 7.4
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,60 @@
+/**
+ * VK Post Author Display - Block Editor Panel
+ * ブロックエディタ用サイドバーパネル
+ *
+ * Replaces the legacy add_meta_box() with PluginDocumentSettingPanel
+ * so that WordPress 7.0 RTC (Real-Time Collaboration) is not blocked.
+ *
+ * @package vk-post-author-display
+ */
+
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginDocumentSettingPanel } from '@wordpress/editor';
+import { CheckboxControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useEntityProp } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+
+const PadHidePanel = () => {
+	const { postType, candidatePostTypes } = useSelect( ( select ) => {
+		const editor = select( 'core/editor' );
+		return {
+			postType: editor.getCurrentPostType(),
+			candidatePostTypes: window.padEditor?.postTypes || [],
+		};
+	}, [] );
+
+	const [ meta, setMeta ] = useEntityProp( 'postType', postType, 'meta' );
+
+	if ( ! candidatePostTypes.includes( postType ) ) {
+		return null;
+	}
+
+	const isHidden = meta?.pad_hide_post_author === 'true';
+
+	return (
+		<PluginDocumentSettingPanel
+			name="pad-hide-panel"
+			title={ __( 'Post Author Display', 'vk-post-author-display' ) }
+			className="pad-hide-panel"
+		>
+			<CheckboxControl
+				label={ __(
+					"Don't display post author",
+					'vk-post-author-display'
+				) }
+				checked={ isHidden }
+				onChange={ ( checked ) =>
+					setMeta( {
+						...meta,
+						pad_hide_post_author: checked ? 'true' : '',
+					} )
+				}
+			/>
+		</PluginDocumentSettingPanel>
+	);
+};
+
+registerPlugin( 'pad-hide-panel', {
+	render: PadHidePanel,
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,9 @@ const PadHidePanel = () => {
 		const editor = select( 'core/editor' );
 		return {
 			postType: editor.getCurrentPostType(),
+			// wp_localize_script で設定された対象投稿タイプ一覧。
+			// データが欠落した場合は空配列にフォールバックし、
+			// すべての投稿タイプでパネルを非表示にする（安全側に倒す）。
 			candidatePostTypes: window.padEditor?.postTypes || [],
 		};
 	}, [] );
@@ -30,6 +33,9 @@ const PadHidePanel = () => {
 		return null;
 	}
 
+	// メタ値は文字列 'true' / '' で管理する。
+	// register_post_meta で type: 'string' を指定しており、
+	// boolean にすると既存データ（レガシーメタボックス由来）との互換性が崩れるため。
 	const isHidden = meta?.pad_hide_post_author === 'true';
 
 	return (

--- a/tests/phpunit/test-register-meta.php
+++ b/tests/phpunit/test-register-meta.php
@@ -42,6 +42,7 @@ class RegisterMetaTest extends WP_UnitTestCase {
 
 	/**
 	 * Test that sanitize_callback strips dangerous content.
+	 * sanitize_callback が危険なコンテンツを除去することを確認する。
 	 */
 	public function test_pad_meta_sanitize() {
 		$meta_keys = get_registered_meta_keys( 'post', 'post' );
@@ -49,11 +50,37 @@ class RegisterMetaTest extends WP_UnitTestCase {
 		$this->assertEquals( 'sanitize_text_field', $sanitize );
 
 		// Verify sanitize_text_field strips HTML tags.
+		// sanitize_text_field が HTML タグを除去することを確認する。
 		$result = sanitize_text_field( '<b>bold</b>' );
 		$this->assertEquals( 'bold', $result );
 
 		// Verify script tags and their content are removed.
+		// script タグとその内容が除去されることを確認する。
 		$result = sanitize_text_field( '<script>alert("xss")</script>' );
 		$this->assertStringNotContainsString( '<script>', $result );
+	}
+
+	/**
+	 * Test that sanitize_callback is applied through the registered meta pipeline.
+	 * register_post_meta のパイプライン経由でサニタイズが実行されることを確認する。
+	 */
+	public function test_pad_meta_sanitize_through_pipeline() {
+		$post_id = self::factory()->post->create();
+
+		// update_post_meta 経由で危険な値を保存し、
+		// register_post_meta の sanitize_callback が適用されることを確認する。
+		update_post_meta( $post_id, 'pad_hide_post_author', '<script>alert("xss")</script>' );
+		$value = get_post_meta( $post_id, 'pad_hide_post_author', true );
+		$this->assertStringNotContainsString( '<script>', $value );
+
+		// 正常値 'true' がそのまま保存されることを確認する。
+		update_post_meta( $post_id, 'pad_hide_post_author', 'true' );
+		$value = get_post_meta( $post_id, 'pad_hide_post_author', true );
+		$this->assertEquals( 'true', $value );
+
+		// 空文字がそのまま保存されることを確認する。
+		update_post_meta( $post_id, 'pad_hide_post_author', '' );
+		$value = get_post_meta( $post_id, 'pad_hide_post_author', true );
+		$this->assertEmpty( $value );
 	}
 }

--- a/tests/phpunit/test-register-meta.php
+++ b/tests/phpunit/test-register-meta.php
@@ -48,8 +48,12 @@ class RegisterMetaTest extends WP_UnitTestCase {
 		$sanitize  = $meta_keys['pad_hide_post_author']['sanitize_callback'];
 		$this->assertEquals( 'sanitize_text_field', $sanitize );
 
-		// Verify sanitize_text_field strips HTML.
+		// Verify sanitize_text_field strips HTML tags.
+		$result = sanitize_text_field( '<b>bold</b>' );
+		$this->assertEquals( 'bold', $result );
+
+		// Verify script tags and their content are removed.
 		$result = sanitize_text_field( '<script>alert("xss")</script>' );
-		$this->assertEquals( 'alert("xss")', $result );
+		$this->assertStringNotContainsString( '<script>', $result );
 	}
 }

--- a/tests/phpunit/test-register-meta.php
+++ b/tests/phpunit/test-register-meta.php
@@ -41,23 +41,24 @@ class RegisterMetaTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that sanitize_callback strips dangerous content.
-	 * sanitize_callback が危険なコンテンツを除去することを確認する。
+	 * Test that sanitize_callback only allows 'true' or empty string.
+	 * sanitize_callback が 'true' / '' のみを許可することを確認する。
 	 */
 	public function test_pad_meta_sanitize() {
 		$meta_keys = get_registered_meta_keys( 'post', 'post' );
 		$sanitize  = $meta_keys['pad_hide_post_author']['sanitize_callback'];
-		$this->assertEquals( 'sanitize_text_field', $sanitize );
+		$this->assertIsCallable( $sanitize );
 
-		// Verify sanitize_text_field strips HTML tags.
-		// sanitize_text_field が HTML タグを除去することを確認する。
-		$result = sanitize_text_field( '<b>bold</b>' );
-		$this->assertEquals( 'bold', $result );
+		// 'true' はそのまま返る。
+		$this->assertEquals( 'true', call_user_func( $sanitize, 'true' ) );
 
-		// Verify script tags and their content are removed.
-		// script タグとその内容が除去されることを確認する。
-		$result = sanitize_text_field( '<script>alert("xss")</script>' );
-		$this->assertStringNotContainsString( '<script>', $result );
+		// 空文字はそのまま返る。
+		$this->assertEquals( '', call_user_func( $sanitize, '' ) );
+
+		// 'true' 以外の文字列は空文字に正規化される。
+		$this->assertEquals( '', call_user_func( $sanitize, 'false' ) );
+		$this->assertEquals( '', call_user_func( $sanitize, 'yes' ) );
+		$this->assertEquals( '', call_user_func( $sanitize, '<script>alert("xss")</script>' ) );
 	}
 
 	/**
@@ -67,11 +68,11 @@ class RegisterMetaTest extends WP_UnitTestCase {
 	public function test_pad_meta_sanitize_through_pipeline() {
 		$post_id = self::factory()->post->create();
 
-		// update_post_meta 経由で危険な値を保存し、
-		// register_post_meta の sanitize_callback が適用されることを確認する。
+		// update_post_meta 経由で不正な値を保存し、
+		// register_post_meta の sanitize_callback で空文字に正規化されることを確認する。
 		update_post_meta( $post_id, 'pad_hide_post_author', '<script>alert("xss")</script>' );
 		$value = get_post_meta( $post_id, 'pad_hide_post_author', true );
-		$this->assertStringNotContainsString( '<script>', $value );
+		$this->assertEmpty( $value );
 
 		// 正常値 'true' がそのまま保存されることを確認する。
 		update_post_meta( $post_id, 'pad_hide_post_author', 'true' );

--- a/tests/phpunit/test-register-meta.php
+++ b/tests/phpunit/test-register-meta.php
@@ -34,7 +34,7 @@ class RegisterMetaTest extends WP_UnitTestCase {
 	 * Test that meta value can be saved and retrieved.
 	 */
 	public function test_meta_save_and_retrieve() {
-		$post_id = $this->factory->post->create();
+		$post_id = self::factory()->post->create();
 		update_post_meta( $post_id, 'pad_hide_post_author', 'true' );
 		$value = get_post_meta( $post_id, 'pad_hide_post_author', true );
 		$this->assertEquals( 'true', $value );

--- a/tests/phpunit/test-register-meta.php
+++ b/tests/phpunit/test-register-meta.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class RegisterMetaTest
+ *
+ * @package vk-post-author-display
+ */
+
+class RegisterMetaTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// Ensure meta is registered for tests.
+		pad_register_post_meta();
+	}
+
+	/**
+	 * Test that pad_hide_post_author meta key is registered for post type.
+	 */
+	public function test_pad_register_post_meta() {
+		$registered = registered_meta_key_exists( 'post', 'pad_hide_post_author', 'post' );
+		$this->assertTrue( $registered, 'pad_hide_post_author should be registered for post type' );
+	}
+
+	/**
+	 * Test that pad_hide_post_author meta has show_in_rest enabled.
+	 */
+	public function test_pad_meta_show_in_rest() {
+		$meta_keys = get_registered_meta_keys( 'post', 'post' );
+		$this->assertArrayHasKey( 'pad_hide_post_author', $meta_keys );
+		$this->assertTrue( $meta_keys['pad_hide_post_author']['show_in_rest'] );
+	}
+
+	/**
+	 * Test that meta value can be saved and retrieved.
+	 */
+	public function test_meta_save_and_retrieve() {
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, 'pad_hide_post_author', 'true' );
+		$value = get_post_meta( $post_id, 'pad_hide_post_author', true );
+		$this->assertEquals( 'true', $value );
+	}
+
+	/**
+	 * Test that sanitize_callback strips dangerous content.
+	 */
+	public function test_pad_meta_sanitize() {
+		$meta_keys = get_registered_meta_keys( 'post', 'post' );
+		$sanitize  = $meta_keys['pad_hide_post_author']['sanitize_callback'];
+		$this->assertEquals( 'sanitize_text_field', $sanitize );
+
+		// Verify sanitize_text_field strips HTML.
+		$result = sanitize_text_field( '<script>alert("xss")</script>' );
+		$this->assertEquals( 'alert("xss")', $result );
+	}
+}


### PR DESCRIPTION
### 関連Issue

- 関連Issue: #120

### 変更の目的・理由

WordPress 7.0 で導入されるリアルタイムコラボレーション（RTC）機能に対応するため、著者表示非表示メタボックスをブロックエディタのネイティブサイドバーパネル（`PluginDocumentSettingPanel`）に移行します。

レガシーな `add_meta_box()` がブロックエディタ上に存在するだけで RTC が無条件にブロックされるため、メタボックスを `__back_compat_meta_box => true` で非表示にし、代わりにネイティブUIで機能を提供します。

### どういう変更をしたか？

**ブロックエディタ:**
- `PluginDocumentSettingPanel` で「Post Author Display」パネルをサイドバーに表示
- `CheckboxControl` で「Don't display post author」チェックボックスを提供
- `register_post_meta()` でメタキー `pad_hide_post_author` を REST API に公開し、ブロックエディタから直接読み書き可能に
- `useEntityProp` フックで phantom dirty 問題を回避（`register_post_meta` に `default` パラメータを設定しない）
- レガシーメタボックスは `__back_compat_meta_box => true` で非表示（ビルドファイル存在時のみ）

**クラシックエディタ:** 従来通りのメタボックスがそのまま動作（変更なし）

**既存ユーザーへの影響:**
- メタキー（`pad_hide_post_author`）は変更なし。既存の設定はそのまま引き継がれる
- フロントエンドの著者表示/非表示動作に変更なし
- クラシックエディタユーザーへの影響なし

**新規ファイル:**
- `src/index.js` — React サイドバーパネル
- `inc/register-meta.php` — メタキーの REST API 登録
- `tests/phpunit/test-register-meta.php` — メタキー登録テスト
- `build/` — ビルド成果物（gitignore対象）

## スクリーンショット

### Before 
<img width="1502" height="841" alt="スクリーンショット 2026-04-09 16 25 27" src="https://github.com/user-attachments/assets/3a745f2c-3047-4cf8-8d21-f7e972a0548c" />

### After 
<img width="1483" height="838" alt="スクリーンショット 2026-04-09 16 19 24" src="https://github.com/user-attachments/assets/8564313a-97aa-4616-91ed-ec78fe1a3415" />

### 修正箇所一覧

| # | ファイル | 操作 | 説明 |
|---|---------|------|------|
| 1 | `inc/register-meta.php` | 新規 | `pad_hide_post_author` をREST APIに登録 |
| 2 | `src/index.js` | 新規 | PluginDocumentSettingPanel サイドバーパネル |
| 3 | `hide_controller.php` | 変更 | `__back_compat_meta_box => true`（ビルド存在時） |
| 4 | `post-author-display.php` | 変更 | register-meta.php の require + ブロックエディタアセット enqueue |
| 5 | `package.json` | 変更 | `@wordpress/scripts` 追加、build スクリプト追加 |
| 6 | `.gitignore` | 変更 | `build/` 追加 |
| 7 | `.distignore` | 変更 | `src/` 追加 |
| 8 | `readme.txt` | 変更 | changelog 更新 |
| 9 | `tests/phpunit/test-register-meta.php` | 新規 | メタキー登録のテスト |

### 実装者チェックリスト

#### コード品質
- [x] 複数の意図の変更を含んでいないか
- [x] 不要なコード整形やフォーマット変更を含んでいない
- [x] 変更ファイルの内容を目視で確認済み

#### ドキュメント
- [x] `readme.txt` に変更内容を記載
- [x] エンドユーザーが理解できる内容で記載

#### テスト
- [x] 書けるテストは実装済み（`tests/phpunit/test-register-meta.php`）
- [x] 既存のテストが通ることを確認
- [x] 手動テストを実施済み

#### 最終確認
- [x] このテンプレートの全項目を確認済み
- [x] レビュワーに回す準備が整っている

---

### レビュワー向け情報

#### テスト手順

##### 前提条件
- WordPress Beta Tester プラグインで **WordPress 7.0 RC** にアップデートしていること
- VK Post Author Display が有効化されていること
- 上記以外のプラグインを一時的に停止すること
- 管理者アカウントが2つあること

##### ビルド手順
```bash
npm install
npm run build
```

##### ネイティブパネル動作確認
1. 投稿の編集画面を開く → サイドバーに「Post Author Display」パネルが表示される
2. 「Don't display post author」チェックボックスが操作可能であること
3. チェックを入れて保存 → 再読み込み → チェック状態が保持されている
4. フロントエンドで投稿を表示 → 著者表示が非表示になっている
5. チェックを外して保存 → フロントエンドで著者表示が復活する

##### RTC 動作確認（WordPress 7.0 RC）
1. 管理画面 > 設定 > 投稿設定 で「Collaboration」を有効にする
2. User1 で投稿の編集画面を開く → サイドバーにネイティブパネルが表示される（レガシーメタボックスは非表示）
3. User2 で別のブラウザ（またはシークレットウィンドウ）から同じ投稿を開く → RTC が有効になっている（右上にアバターが2つ表示される）
4. User1 がタイトルや本文を変更する → User2 側にリアルタイムで反映されること

##### デグレ確認（WordPress 6.x）
1. WordPress Beta Tester プラグインで 6.x に戻す（または別環境で確認）
2. 投稿編集画面を開く → 「Post Author Display」メタボックスが正常に表示される
3. メタボックスで設定を変更し保存する → 設定が正常に保存される（既存動作に影響なし）

##### ビルドファイル非存在時のフォールバック確認
1. `build/` ディレクトリを削除する
2. 投稿編集画面を開く → レガシーメタボックスが従来通り表示される
3. メタボックスの操作が正常に動作する

#### レビューポイント（任意）
- `hide_controller.php` で `build/index.asset.php` の存在チェックが正しく機能しているか
- `register_post_meta()` に `default` パラメータが設定されていないこと（phantom dirty 問題防止）
- `useEntityProp` フックを使用していること（`editPost` ではなく）
- `array_values()` で投稿タイプ配列を正規化しているか
- 既存の引数が変更されていないか

#### 動作確認時の注意事項
- [ ] 最新のコードをプルしている
- [ ] ビルドを実行している（`npm run build`）
- [ ] 正しいディレクトリで作業している
- [ ] キャッシュをクリアしている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ブロックエディターのネイティブサイドバーパネルで「投稿著者を非表示」に切替可能に
  * エディター用スクリプトを条件付きで読み込み、対象投稿タイプを限定して動作
  * 投稿タイプごとのメタキーを登録し、REST経由で利用可能に

* **テスト**
  * メタデータ登録・保存・サニタイズに関する単体テストを追加

* **ドキュメント**
  * changelog に移行に関する記載を追加

* **その他**
  * ビルド／開発スクリプト強化、配布／バージョン管理の除外設定を更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->