### PR TITLE
[ 仕様変更 ] vektor-inc/font-awesome-versions を 0.7.2 から 0.7.4 にアップデート

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"require": {
 		"vektor-inc/vk-admin": "^0.8.0",
-		"vektor-inc/font-awesome-versions": "0.7.2"
+		"vektor-inc/font-awesome-versions": "^0.7.4"
 	},
 	"require-dev": {
 		"doctrine/instantiator": "1.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a3e9a6ea1a1e49d60a78e427785d05c",
+    "content-hash": "f9c9110245b99e4fc4b350b34ee9ae00",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.2",
+            "version": "0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "ec8458a56165dc309befe88c982a54bda4bcb2e4"
+                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/ec8458a56165dc309befe88c982a54bda4bcb2e4",
-                "reference": "ec8458a56165dc309befe88c982a54bda4bcb2e4",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
+                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.2"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.4"
             },
-            "time": "2026-03-19T04:34:56+00:00"
+            "time": "2026-06-26T02:51:54+00:00"
         },
         {
             "name": "vektor-inc/vk-admin",

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,8 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.4
+
 [ Bug fix ] Fix an issue on the settings screen where admin styles and scripts were sometimes not applied after an update due to caching.
 [ Bug fix ] Fix the left side navigation being cut off on the settings screen while a notice was displayed.
 


### PR DESCRIPTION
誤ってrevertされた font-awesome-versions 0.7.4 アップデートを復元します。

関連Issue: なし

## 変更内容

- revertコミット `3322a59` を取り消し、0.7.4 アップデートを再適用

## 確認手順

1. `composer install` を実行する → エラーなく完了する
2. `composer show vektor-inc/font-awesome-versions` → `versions : * 0.7.4` と表示される