### PR TITLE
[ 開発環境 ] PHPUnit テストをリリース時と run-ci ラベル付き PR のみ実行に変更

### DIFF
--- a/.github/workflows/php-unit-test.yml
+++ b/.github/workflows/php-unit-test.yml
@@ -5,8 +5,10 @@ on:
             - master
             - develop
             - ^feature/.+
+        types: [opened, reopened, labeled, synchronize]
 jobs:
     php_unit:
+        if: contains(github.event.pull_request.labels.*.name, 'run-ci')
         runs-on: ubuntu-latest
         strategy:
             matrix:


### PR DESCRIPTION
## 概要
GitHub Actions の消費削減のため、PHPUnit テストのワークフローを「リリース時と `run-ci` ラベル付き PR のときだけ実行」する構成に変更します。

## 変更内容
- `.github/workflows/php-unit-test.yml`
  - `on.pull_request.types` に `[opened, reopened, labeled, synchronize]` を追加
  - `php_unit` ジョブに `if: contains(github.event.pull_request.labels.*.name, 'run-ci')` を追加
  - 元々 `on.push` トリガーは無いため push での自動実行は元から発生しない

## 確認手順
1. ラベル無しの PR ではワークフローが起動しない（ジョブが skip される）
2. `run-ci` ラベルを付与すると起動する
3. push では起動しない
4. リリース時は従来どおり（release.yml は変更していない）

CI 設定のみの変更でプラグイン動作に影響はありません。

関連: vektor-inc/multi-repo-tasks#24
