### PR TITLE
[ 不具合修正 ] ウィジェット編集画面で pad-editor-panel スクリプトが読み込まれて PHP notice が記録される不具合を修正

### DIFF
--- a/post-author-display.php
+++ b/post-author-display.php
@@ -90,9 +90,19 @@ require_once VK_PAD_DIR . 'hide_controller.php';
  * Enqueue block editor assets for the native sidebar panel.
  * ブロックエディタ用ネイティブサイドバーパネルのアセットを読み込む。
  *
+ * 投稿タイプのあるブロックエディター画面（投稿・固定ページ等）でのみ実行する。
+ * ウィジェット編集画面（widgets.php）では wp-editor スクリプトをエンキューすると
+ * PHP notice が発生するため、post_type が空の場合は早期リターンする。
+ *
  * @return void
  */
 function pad_enqueue_block_editor_assets() {
+	// ウィジェット編集画面（wp-edit-widgets / wp-customize-widgets）では実行しない。
+	$screen = get_current_screen();
+	if ( ! $screen || ! $screen->is_block_editor || empty( $screen->post_type ) ) {
+		return;
+	}
+
 	$asset_path = VK_PAD_DIR . 'build/index.asset.php';
 	if ( ! file_exists( $asset_path ) ) {
 		return;

--- a/post-author-display.php
+++ b/post-author-display.php
@@ -91,13 +91,16 @@ require_once VK_PAD_DIR . 'hide_controller.php';
  * ブロックエディタ用ネイティブサイドバーパネルのアセットを読み込む。
  *
  * 投稿タイプのあるブロックエディター画面（投稿・固定ページ等）でのみ実行する。
+ * Only runs on block editor screens that have a post type.
  * ウィジェット編集画面（widgets.php）では wp-editor スクリプトをエンキューすると
  * PHP notice が発生するため、post_type が空の場合は早期リターンする。
+ * Skips widget editor screens to prevent the PHP notice.
  *
  * @return void
  */
 function pad_enqueue_block_editor_assets() {
 	// ウィジェット編集画面（wp-edit-widgets / wp-customize-widgets）では実行しない。
+	// Skip on widget editor screens (wp-edit-widgets / wp-customize-widgets).
 	$screen = get_current_screen();
 	if ( ! $screen || ! $screen->is_block_editor || empty( $screen->post_type ) ) {
 		return;

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,8 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
+[ Bug fix ] Fix an issue where the pad-editor-panel script was loaded on the widget editing screen, causing a PHP notice about wp-editor.
+
 [ New Feature ] Add GitHub, Bluesky and Threads social icons.
 
 [ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.4

--- a/tests/phpunit/test-enqueue-guard.php
+++ b/tests/phpunit/test-enqueue-guard.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class EnqueueGuardTest
+ *
+ * @package vk-post-author-display
+ */
+
+/**
+ * pad_enqueue_block_editor_assets() のスクリーンガードテスト。
+ * Screen guard tests for pad_enqueue_block_editor_assets().
+ */
+class EnqueueGuardTest extends WP_UnitTestCase {
+
+	/**
+	 * Current_screen が null の時は何もエンキューしない。
+	 * Does nothing when current_screen is null.
+	 *
+	 * @return void
+	 */
+	public function test_pad_enqueue_guard_no_screen() {
+		$GLOBALS['current_screen'] = null;
+		pad_enqueue_block_editor_assets();
+		$this->assertFalse( wp_script_is( 'pad-editor-panel', 'enqueued' ) );
+	}
+
+	/**
+	 * Is_block_editor が false の時は何もエンキューしない。
+	 * Does nothing when is_block_editor is false.
+	 *
+	 * @return void
+	 */
+	public function test_pad_enqueue_guard_not_block_editor() {
+		$screen                    = WP_Screen::get( 'widgets' );
+		$screen->is_block_editor   = false;
+		$GLOBALS['current_screen'] = $screen;
+		pad_enqueue_block_editor_assets();
+		$this->assertFalse( wp_script_is( 'pad-editor-panel', 'enqueued' ) );
+		$GLOBALS['current_screen'] = null;
+	}
+
+	/**
+	 * Post_type が空の時は何もエンキューしない。
+	 * Does nothing when post_type is empty.
+	 *
+	 * @return void
+	 */
+	public function test_pad_enqueue_guard_empty_post_type() {
+		$screen                    = WP_Screen::get( 'widgets' );
+		$screen->is_block_editor   = true;
+		$GLOBALS['current_screen'] = $screen;
+		pad_enqueue_block_editor_assets();
+		$this->assertFalse( wp_script_is( 'pad-editor-panel', 'enqueued' ) );
+		$GLOBALS['current_screen'] = null;
+	}
+}

--- a/tests/phpunit/test-enqueue-guard.php
+++ b/tests/phpunit/test-enqueue-guard.php
@@ -12,6 +12,52 @@
 class EnqueueGuardTest extends WP_UnitTestCase {
 
 	/**
+	 * Saved current_screen value restored after each test.
+	 *
+	 * @var WP_Screen|null
+	 */
+	private $_original_screen;
+
+	/**
+	 * Save the original current_screen before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->_original_screen = isset( $GLOBALS['current_screen'] )
+			? $GLOBALS['current_screen']
+			: null;
+	}
+
+	/**
+	 * Restore current_screen and dequeue test scripts after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$GLOBALS['current_screen'] = $this->_original_screen;
+		wp_dequeue_script( 'pad-editor-panel' );
+		wp_deregister_script( 'pad-editor-panel' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Is_block_editor が true かつ post_type がある時に script がエンキューされる。
+	 * Enqueues script when is_block_editor is true and post_type is set.
+	 *
+	 * @return void
+	 */
+	public function test_pad_enqueue_happy_path() {
+		$screen                    = WP_Screen::get( 'post' );
+		$screen->is_block_editor   = true;
+		$screen->post_type         = 'post';
+		$GLOBALS['current_screen'] = $screen;
+		pad_enqueue_block_editor_assets();
+		$this->assertTrue( wp_script_is( 'pad-editor-panel', 'enqueued' ) );
+	}
+
+	/**
 	 * Current_screen が null の時は何もエンキューしない。
 	 * Does nothing when current_screen is null.
 	 *
@@ -35,7 +81,6 @@ class EnqueueGuardTest extends WP_UnitTestCase {
 		$GLOBALS['current_screen'] = $screen;
 		pad_enqueue_block_editor_assets();
 		$this->assertFalse( wp_script_is( 'pad-editor-panel', 'enqueued' ) );
-		$GLOBALS['current_screen'] = null;
 	}
 
 	/**
@@ -50,6 +95,5 @@ class EnqueueGuardTest extends WP_UnitTestCase {
 		$GLOBALS['current_screen'] = $screen;
 		pad_enqueue_block_editor_assets();
 		$this->assertFalse( wp_script_is( 'pad-editor-panel', 'enqueued' ) );
-		$GLOBALS['current_screen'] = null;
 	}
 }


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

関連Issue: vektor-inc/multi-repo-tasks#25

## どういう変更をしたか？

`enqueue_block_editor_assets`（ブロックエディター用アセット読み込みフック）は投稿編集画面だけでなく、ウィジェット編集画面（`widgets.php`）でも発火します。`pad-editor-panel` スクリプトのビルド依存（`build/index.asset.php` の `dependencies`）に `wp-editor` が含まれているため、ウィジェット編集画面でもこのスクリプトが読み込まれて以下の notice が記録されていました。

```
PHP Notice: 関数 wp_enqueue_script() が誤って呼び出されました。wp-editor スクリプトを新しいウィジェットエディター (wp-edit-widgets または wp-customize-widgets) と一緒にエンキューしないでください。
```

`pad_enqueue_block_editor_assets()` の先頭に `get_current_screen()` を使った画面判定を追加し、投稿タイプのあるブロックエディター画面でのみスクリプトを読み込むよう修正しました。

**変更ファイル:**
- `post-author-display.php` — `pad_enqueue_block_editor_assets()` にスクリーンガード追加

## 実装者の確認事項

- [x] 複数の意図の変更（機能の不具合修正 + 別の機能追加など）を含んでいないか？
- [x] Files changed (変更ファイル) の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？

`get_current_screen()` のスクリーンガードをテストするには `WP_Screen` オブジェクトのプロパティモックが必要で、現在のテスト構成では複雑度が高いためスキップしています。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

**Before（修正前の再現手順）:**

**前提:** プラグインで vk-post-author-display のみ有効化する。WP_DEBUG / WP_DEBUG_LOG を有効にする

1. master ブランチの状態で、管理画面の「外観 > ウィジェット」を開く
2. `wp-content/debug.log` を確認する
→ `PHP Notice: 関数 wp_enqueue_script() が誤って呼び出されました。wp-editor スクリプトを...` が記録されている

**After（修正後の確認手順）:**

1. このブランチの変更を適用した状態で、管理画面の「外観 > ウィジェット」を開く
2. `wp-content/debug.log` を確認する
→ 上記 notice が記録されなくなっている

**デグレ確認:**

1. 管理画面の「投稿 > 新規追加」でブロックエディターを開く
2. ドキュメントサイドバーに投稿者情報パネルが表示されることを確認する
→ 投稿編集画面では引き続き正常に動作する

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* `WP_DEBUG=true` の環境でウィジェット編集画面を開き `debug.log` に notice が記録されなくなっていることを確認する
* 投稿編集画面でサイドバーパネルが正常に表示されることを確認する（デグレ確認）

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

* プルしたか？
* キャッシュをクリアして確認したか？
