### PR TITLE
[ 仕様変更 ] font-awesome-versions を 0.7.4 から 0.7.5 に更新

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"require": {
 		"vektor-inc/vk-admin": "^0.8.0",
-		"vektor-inc/font-awesome-versions": "^0.7.4"
+		"vektor-inc/font-awesome-versions": "^0.7.5"
 	},
 	"require-dev": {
 		"doctrine/instantiator": "1.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9c9110245b99e4fc4b350b34ee9ae00",
+    "content-hash": "5cf3d64ee36db933867a8b51acf40dad",
     "packages": [
         {
             "name": "vektor-inc/font-awesome-versions",
-            "version": "0.7.4",
+            "version": "0.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vektor-inc/font-awesome-versions.git",
-                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa"
+                "reference": "0f13392629e0af4b6595c5dca59c65d9e854780c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
-                "reference": "75ccd1f213aa596be875a63b0e6ffef70b00e2aa",
+                "url": "https://api.github.com/repos/vektor-inc/font-awesome-versions/zipball/0f13392629e0af4b6595c5dca59c65d9e854780c",
+                "reference": "0f13392629e0af4b6595c5dca59c65d9e854780c",
                 "shasum": ""
             },
             "require": {
@@ -54,9 +54,9 @@
             "description": "Font Awesome",
             "support": {
                 "issues": "https://github.com/vektor-inc/font-awesome-versions/issues",
-                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.4"
+                "source": "https://github.com/vektor-inc/font-awesome-versions/tree/0.7.5"
             },
-            "time": "2026-06-26T02:51:54+00:00"
+            "time": "2026-07-08T05:37:47+00:00"
         },
         {
             "name": "vektor-inc/vk-admin",

--- a/readme.txt
+++ b/readme.txt
@@ -35,7 +35,7 @@ Display to Post Author Information Box on bottom of the contents.
 
 [ New Feature ] Add GitHub, Bluesky and Threads social icons.
 
-[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.4
+[ Spec Change ] Update vektor-inc/font-awesome-versions from 0.7.2 to 0.7.5
 
 [ Bug fix ] Fix an issue on the settings screen where admin styles and scripts were sometimes not applied after an update due to caching.
 [ Bug fix ] Fix the left side navigation being cut off on the settings screen while a notice was displayed.


### PR DESCRIPTION
## 概要

Composer パッケージ `vektor-inc/font-awesome-versions` を 0.7.4 から 0.7.5 に更新します。

- `composer.json` の制約を `^0.7.4` → `^0.7.5` に更新
- `composer update vektor-inc/font-awesome-versions` を実行し `composer.lock`（バージョン・content-hash）を更新
- `readme.txt` の changelog を「from 0.7.2 to 0.7.5」に更新（0.7.4 は未リリースのため既存エントリを書き換え）

## 確認手順

1. このブランチをチェックアウトし、`composer install` を実行する
   → `vendor/vektor-inc/font-awesome-versions` が 0.7.5 でインストールされる
2. `composer show vektor-inc/font-awesome-versions | grep versions` を実行する
   → `versions : 0.7.5` と表示される
3. 投稿者情報を表示するページで Font Awesome の SNS アイコンが従来どおり表示されることを確認する
   → アイコン表示に崩れ・欠落がない（デグレなし）

純粋なライブラリのバージョンアップで、プラグイン側のコード・表示ロジックに変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
