### PR TITLE
[ 不具合修正 ] SNSアイコンリンクに aria-label と rel="noopener noreferrer" を追加してスクリーンリーダーの匿名リンクを解消

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,8 @@ Display to Post Author Information Box on bottom of the contents.
 
 == Changelog ==
 
+[ Bug fix ] Add aria-label and rel="noopener noreferrer" to social icon links so screen readers can identify each link (WCAG 2.1 AA 2.4.4).
+
 [ Bug fix ] Fix an issue where the pad-editor-panel script was loaded on the widget editing screen, causing a PHP notice about wp-editor.
 
 [ New Feature ] Add GitHub, Bluesky and Threads social icons.

--- a/tests/phpunit/test-social-icons.php
+++ b/tests/phpunit/test-social-icons.php
@@ -112,10 +112,48 @@ class SocialIconsTest extends WP_UnitTestCase {
 				'expected_present'    => true,
 			),
 			array(
+				// Accessibility: each link must carry an aria-label with the SNS name (WCAG 2.4.4).
+				// アクセシビリティ：各リンクに SNS 名の aria-label が付与される（WCAG 2.4.4 対応）。
+				'test_condition_name' => 'github リンクに aria-label="GitHub" が付与される',
+				'needle'              => 'aria-label="GitHub"',
+				'expected_present'    => true,
+			),
+			array(
+				'test_condition_name' => 'bluesky リンクに aria-label="Bluesky" が付与される',
+				'needle'              => 'aria-label="Bluesky"',
+				'expected_present'    => true,
+			),
+			array(
+				'test_condition_name' => 'threads リンクに aria-label="Threads" が付与される',
+				'needle'              => 'aria-label="Threads"',
+				'expected_present'    => true,
+			),
+			array(
+				// Security: target="_blank" links must carry rel="noopener noreferrer" ( tabnabbing 対策 ).
+				// セキュリティ：target="_blank" のリンクに rel="noopener noreferrer" が付与される（ タブナビング対策 ）。
+				'test_condition_name' => 'リンクに rel="noopener noreferrer" が付与される',
+				'needle'              => 'rel="noopener noreferrer"',
+				'expected_present'    => true,
+			),
+			array(
+				// Accessibility: decorative icon must be hidden from screen readers.
+				// アクセシビリティ：装飾アイコンはスクリーンリーダーから隠す。
+				'test_condition_name' => '装飾アイコン i 要素に aria-hidden="true" が付与される',
+				'needle'              => 'aria-hidden="true"',
+				'expected_present'    => true,
+			),
+			array(
 				// Boundary: SNS without a URL must not render a link.
 				// 境界値：URL 未設定の SNS はリンクが出力されない。
 				'test_condition_name' => 'URL 未設定の facebook アイコンは出力されない',
 				'needle'              => 'fa-square-facebook',
+				'expected_present'    => false,
+			),
+			array(
+				// Boundary: an unset SNS name must not appear as an aria-label.
+				// 境界値：未設定 SNS の名前は aria-label として出力されない。
+				'test_condition_name' => 'URL 未設定の facebook の aria-label="Facebook" は出力されない',
+				'needle'              => 'aria-label="Facebook"',
 				'expected_present'    => false,
 			),
 		);

--- a/view.post-author.php
+++ b/view.post-author.php
@@ -105,8 +105,7 @@ if ( ! class_exists( 'Vk_Post_Author_Box' ) ) {
 				} // if ( $key == 'twitter' ){
 
 				if ( $sns_url ) {
-					$sns_icons .= '<li class="pad_' . $key . '"><a href="' . esc_url( $sns_url ) . '" target
-					="_blank" class="' . $key . '"><i class="' . esc_attr( $value['icon_class'] ) . '"></i></a></li>';
+					$sns_icons .= '<li class="pad_' . $key . '"><a href="' . esc_url( $sns_url ) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr( $value['name'] ) . '" class="' . $key . '"><i class="' . esc_attr( $value['icon_class'] ) . '" aria-hidden="true"></i></a></li>';
 				}
 			}
 

--- a/view.post-author.php
+++ b/view.post-author.php
@@ -105,6 +105,7 @@ if ( ! class_exists( 'Vk_Post_Author_Box' ) ) {
 				} // if ( $key == 'twitter' ){
 
 				if ( $sns_url ) {
+					// アイコンのみのリンクに aria-label でアクセシブルネームを付与し、装飾アイコンは aria-hidden で読み上げを抑制（WCAG 2.4.4 対応）。target="_blank" にはタブナビング対策として rel="noopener noreferrer" を付与.
 					$sns_icons .= '<li class="pad_' . $key . '"><a href="' . esc_url( $sns_url ) . '" target="_blank" rel="noopener noreferrer" aria-label="' . esc_attr( $value['name'] ) . '" class="' . $key . '"><i class="' . esc_attr( $value['icon_class'] ) . '" aria-hidden="true"></i></a></li>';
 				}
 			}


### PR DESCRIPTION
## 概要

SNS アイコンリンクが icon-only（アイコンのみ）で出力されており、リンクに識別可能なテキストがないためスクリーンリーダーで「匿名リンク（リンクテキストなし）」として読み上げられていました。WCAG 2.1 AA 達成基準 2.4.4（リンクの目的（コンテキスト内））違反です。

`view.post-author.php` の SNS アイコン出力の `<a>` タグに以下を追加して修正します。

- `aria-label="<SNS名>"` … スクリーンリーダーが各リンクの目的を判別できるようにする（SNS 名は `pad_sns_array()` の `name` を `esc_attr()` でエスケープして出力）
- `rel="noopener noreferrer"` … `target="_blank"` の外部リンクに対するセキュリティ対策（tabnabbing 対策・リファラ抑止）
- アイコンの `<i>` に `aria-hidden="true"` … 装飾目的のアイコンをアクセシビリティツリーから隠し、`aria-label` のみを読ませる

あわせて、文字列リテラル内で `target` と `="_blank"` が改行されていた不自然な記述を 1 行に整形しました。

Closes #131

## 変更ファイル

- `view.post-author.php` … SNS アイコンリンク `<a>` に `aria-label` / `rel="noopener noreferrer"` を追加、`<i>` に `aria-hidden="true"` を追加、`target` 属性の改行を整形
- `readme.txt` … Changelog 追記

## 確認手順

### 前提条件
- VK Post Author Display を有効化
- 任意のユーザーのプロフィール編集画面（管理画面 > ユーザー > プロフィール）で、SNS の URL を 1 つ以上入力して保存（例: 「X」欄に `https://x.com/xxxx`、「GitHub」欄に `https://github.com/xxxx` など）
- そのユーザーを投稿者とする投稿を 1 件公開し、投稿者情報ボックス（Post Author Box）が表示される状態にする

### Before（修正前の再現手順）
1. 公開側で投稿を開き、投稿者情報ボックスの SNS アイコンを表示する
2. 開発者ツールで SNS アイコンリンクの `<a>` 要素を確認する
   → ✗ `aria-label` が無く、リンク内はアイコン（`<i>`）だけでテキストが無い
   → ✗ `rel="noopener noreferrer"` が付いていない
   → ✗ スクリーンリーダーではリンクの目的が読み上げられず匿名リンクになる

### After（修正後）
1. 公開側で投稿を開き、投稿者情報ボックスの SNS アイコンを表示する
2. SNS アイコンにマウスオーバーする、または開発者ツールで `<a>` 要素を確認する
   → ✓ `<a>` に `aria-label="X"`（GitHub なら `aria-label="GitHub"` 等）が付与されている
   → ✓ `<a>` に `rel="noopener noreferrer"` が付与されている
   → ✓ アイコンの `<i>` に `aria-hidden="true"` が付与されている
3. スクリーンリーダー（VoiceOver 等）でリンクに移動する
   → ✓ 「X, リンク」のように SNS 名が読み上げられ、リンクの目的が判別できる
4. アイコンをクリックする
   → ✓ 従来どおり別タブで該当 SNS ページが開く（デグレ無し）
5. 複数の SNS URL を設定した場合
   → ✓ それぞれの `<a>` に対応する SNS 名の `aria-label` が付与される

## テストについて

`tests/phpunit/test-social-icons.php` の `test_get_social_icons()` を拡張し、SNS アイコン出力に以下が含まれることを検証するアサーションを追加しました。

- `<a>` に `aria-label="<SNS名>"`（GitHub / Bluesky / Threads）が付与されること
- `<a>` に `rel="noopener noreferrer"` が付与されること
- 装飾アイコン `<i>` に `aria-hidden="true"` が付与されること
- URL 未設定の SNS（Facebook）では `aria-label` が出力されないこと（描画時のみ付与される確認）

`npm run phpunit` および CI（PHP 8.2 × WP 6.6/6.7/6.8）で全テスト green を確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SNSアイコンリンクに `aria-label` を追加し、スクリーンリーダーで各リンクを識別しやすくしました。
  * 外部リンクに `rel="noopener noreferrer"` を付与し、安全性を高めました。
  * アイコンの `i` 要素を装飾扱い（`aria-hidden="true"`）にし、読み上げの重複を減らしました。
* **Documentation**
  * 更新履歴にアクセシビリティ改善（WCAG 2.1 AA 2.4.4）を追記しました。
* **Tests**
  * SNSアイコン出力に対する追加検証（`aria-label`/`rel`/`aria-hidden`、Facebook未設定時の非出力）を行うよう更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
