### PR TITLE
[ 開発環境 ] CI の WordPress テストバージョンを 7.0 まで含むよう更新

### DIFF
--- a/.github/workflows/php-unit-test.yml
+++ b/.github/workflows/php-unit-test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['8.2']
-                wp-versions: ['6.9', '6.8', '6.7']
+                wp-versions: ['7.0', '6.9', '6.8']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:

--- a/.github/workflows/php-unit-test.yml
+++ b/.github/workflows/php-unit-test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['8.2']
-                wp-versions: ['6.8', '6.7', '6.6']
+                wp-versions: ['6.9', '6.8', '6.7']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['7.4', '8.1']
-                wp-versions: ['6.7', '6.8', '6.9']
+                wp-versions: ['6.8', '6.9', '7.0']
         name: PHP Unit Test on PHP ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test
         services:
             mysql:


### PR DESCRIPTION
## 概要

CI（GitHub Actions）でテスト対象とする WordPress バージョンを、それぞれ 1 つずつ上にずらしました。これにより、最新の WordPress 7.0 がリリーステスト対象に含まれるようになります。

関連 issue: https://github.com/vektor-inc/vk-post-author-display/issues/138

## 変更内容

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `.github/workflows/php-unit-test.yml`（PR CI） | `['6.8', '6.7', '6.6']` | `['6.9', '6.8', '6.7']` |
| `.github/workflows/release.yml`（リリース時） | `['6.7', '6.8', '6.9']` | `['6.8', '6.9', '7.0']` |

- 既存のスタイル（配列の並び順・クオート・インデント）はそのままに、各バージョンを 1 つずつ繰り上げています。
- PR CI とリリース時テストの間の「リリース時は 1 バージョン新しいものまでテストする」という既存のずれも維持しています。

## changelog について

本変更は GitHub Actions のワークフロー設定変更のため、`readme.txt` / `CHANGELOG.md` への changelog 追記は不要です（vk-agents `rules/changelog.md` の「更新不要なケース」に該当）。

## 確認手順

1. このブランチの `.github/workflows/php-unit-test.yml` を開く → `wp-versions` が `['6.9', '6.8', '6.7']` になっていること。
2. `.github/workflows/release.yml` を開く → `wp-versions` が `['6.8', '6.9', '7.0']` になっていること。
3. 変更が上記 2 ファイル・2 行のみで、他のワークフローや `uses:` の action 参照・シークレット等に変更がないこと（`git diff origin/master...HEAD` で確認）。
4. （実際の CI 実行時）この PR に `run-ci` ラベルを付与すると、PHP Unit Test が WP 6.9 / 6.8 / 6.7 のマトリクスで走る。リリース時のワークフローでは WP 6.8 / 6.9 / 7.0 が対象になる。

→ 上記が確認できれば OK です。

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/298